### PR TITLE
[feature] 회원가입 API

### DIFF
--- a/src/main/java/com/snsIntegrationFeedService/SnsIntegrationFeedServiceApplication.java
+++ b/src/main/java/com/snsIntegrationFeedService/SnsIntegrationFeedServiceApplication.java
@@ -2,8 +2,9 @@ package com.snsIntegrationFeedService;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class SnsIntegrationFeedServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/snsIntegrationFeedService/common/error/CustomErrorCode.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/error/CustomErrorCode.java
@@ -7,9 +7,20 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum CustomErrorCode {
-	POST_ID_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 게시글 아이디입니다."),
-	USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 사용자입니다."),
-	;
+	POST_ID_NOT_FOUND(HttpStatus.BAD_REQUEST.value(),
+			"존재하지 않는 게시글 아이디입니다."),
+	USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(),
+			"이미 존재하는 사용자입니다."),
+	CONTAIN_PRIVATE_INFORMATION(HttpStatus.BAD_REQUEST.value(),
+			"비밀번호에 개인정보를 포함할 수 없습니다."),
+	LACK_OF_CHARACTERS(HttpStatus.BAD_REQUEST.value(),
+			"비밀번호는 10자 이상이어야 합니다."),
+	NOT_AVAILABLE_COMMON_PASSWORD(HttpStatus.BAD_REQUEST.value(),
+			"통상적으로 사용되는 비밀번호는 사용할 수 없습니다."),
+	NOT_FOLLOW_RULES(HttpStatus.BAD_REQUEST.value(),
+			"숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다."),
+	NOT_THREE_CONSECUTIVE(HttpStatus.BAD_REQUEST.value(),
+			"3회 이상 연속되는 문자 사용이 불가합니다.");
 
 	private final int errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/snsIntegrationFeedService/common/error/CustomErrorCode.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/error/CustomErrorCode.java
@@ -7,9 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum CustomErrorCode {
-	// 예시 에러코드입니다.
-	USER_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 사용자입니다."),
 	POST_ID_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 게시글 아이디입니다."),
+	USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 사용자입니다."),
 	;
 
 	private final int errorCode;

--- a/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
 	@PostMapping("/signup")
 	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
 		userService.signup(requestDto);
-		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "회원 가입 완료"));
+		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "회원 가입 완료"));
 	}
 
 

--- a/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
@@ -1,4 +1,32 @@
 package com.snsIntegrationFeedService.user.controller;
 
+import com.snsIntegrationFeedService.common.dto.ApiResponseDto;
+import com.snsIntegrationFeedService.user.dto.SignupRequestDto;
+import com.snsIntegrationFeedService.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "사용자 API", description = "사용자와 관련된 API 정보를 담고 있습니다.")
 public class UserController {
+	private final UserService userService;
+
+	@Operation(summary = "회원 가입", description = "가입에 필요한 정보를 받아 회원가입합니다.")
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+		userService.signup(requestDto);
+		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "회원 가입 완료"));
+	}
+
+
 }

--- a/src/main/java/com/snsIntegrationFeedService/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/dto/SignupRequestDto.java
@@ -1,4 +1,21 @@
 package com.snsIntegrationFeedService.user.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class SignupRequestDto {
+
+	@NotBlank
+	private String account;
+
+	@NotBlank
+	@Email
+	private String email;
+
+	@NotBlank
+	private String password;
 }

--- a/src/main/java/com/snsIntegrationFeedService/user/entity/User.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/entity/User.java
@@ -3,13 +3,19 @@ package com.snsIntegrationFeedService.user.entity;
 import com.snsIntegrationFeedService.certificateCode.entity.CertificateCode;
 import com.snsIntegrationFeedService.post.entity.Post;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class User {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,6 +31,7 @@ public class User {
 	private String email;
 
 	@Column(nullable = false)
+	@Builder.Default
 	private Boolean isAccessed = false;
 
 	@OneToMany(mappedBy = "user", orphanRemoval = true)

--- a/src/main/java/com/snsIntegrationFeedService/user/repository/UserRepository.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/repository/UserRepository.java
@@ -1,4 +1,12 @@
 package com.snsIntegrationFeedService.user.repository;
 
-public interface UserRepository {
+import com.snsIntegrationFeedService.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByAccount(String account);
 }

--- a/src/main/java/com/snsIntegrationFeedService/user/service/CommonPassword.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/CommonPassword.java
@@ -1,0 +1,25 @@
+package com.snsIntegrationFeedService.user.service;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CommonPassword {
+	private final List<String> commonPasswordList;
+
+	public CommonPassword() {
+		String[] commonPasswordArray = {
+				"col123456", "D1lakiss", "110110jp", "Gizli", "abc123", "azerty",
+				"1q2w3e4r", "pass@123", "qwerty123", "123qwe", "a1b2c3", "Groupd2013",
+				"1q2w3e", "Liman1000", "1qaz2wsx", "password1", "mar20lt", "abcd1234",
+				"luzit2000", "1234qwer", "qwe123", "super123", "qwer1234", "123456789a",
+				"823477aA", "q1w2e3r4", "123456a", "asdf1234", "123abc", "asd123",
+				"lol123", "a123456", "qwerty1", "Indya123", "anmol123", "1qazxsw2",
+				"12345qwert", "q1w2e3", "zaq12wsx", "password123", "wow12345", "12qwaszx",
+				"Pass@123", "passw0rd", "Password1"};
+		this.commonPasswordList = Arrays.asList(commonPasswordArray);
+	}
+
+	public boolean isCommonPassword(String password) {
+		return commonPasswordList.contains(password);
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/user/service/CommonPassword.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/CommonPassword.java
@@ -1,21 +1,16 @@
 package com.snsIntegrationFeedService.user.service;
 
+import org.springframework.stereotype.Component;
+
 import java.util.Arrays;
 import java.util.List;
 
+@Component
 public class CommonPassword {
 	private final List<String> commonPasswordList;
 
 	public CommonPassword() {
-		String[] commonPasswordArray = {
-				"col123456", "D1lakiss", "110110jp", "Gizli", "abc123", "azerty",
-				"1q2w3e4r", "pass@123", "qwerty123", "123qwe", "a1b2c3", "Groupd2013",
-				"1q2w3e", "Liman1000", "1qaz2wsx", "password1", "mar20lt", "abcd1234",
-				"luzit2000", "1234qwer", "qwe123", "super123", "qwer1234", "123456789a",
-				"823477aA", "q1w2e3r4", "123456a", "asdf1234", "123abc", "asd123",
-				"lol123", "a123456", "qwerty1", "Indya123", "anmol123", "1qazxsw2",
-				"12345qwert", "q1w2e3", "zaq12wsx", "password123", "wow12345", "12qwaszx",
-				"Pass@123", "passw0rd", "Password1"};
+		String[] commonPasswordArray = {"Groupd2013", "123456789a", "12345qwert", "password123"};
 		this.commonPasswordList = Arrays.asList(commonPasswordArray);
 	}
 

--- a/src/main/java/com/snsIntegrationFeedService/user/service/PasswordValidation.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/PasswordValidation.java
@@ -9,9 +9,6 @@ import java.util.regex.Pattern;
 
 @Component
 public class PasswordValidation {
-	String account;
-	String email;
-	String password;
 	private final CommonPassword commonPassword;
 
 	public PasswordValidation(CommonPassword commonPassword) {
@@ -19,12 +16,12 @@ public class PasswordValidation {
 	}
 
 	public void validatePassword(SignupRequestDto requestDto) {
-		this.account = requestDto.getAccount();
-		this.email = requestDto.getEmail();
-		this.password = requestDto.getPassword();
+		String account =  requestDto.getAccount();
+		String email = requestDto.getEmail();
+		String password = requestDto.getPassword();
 
 		// 다른 개인 정보와 유사한 비밀번호는 사용할 수 없다.
-		if (containPrivateInformation()) {
+		if (containPrivateInformation(account, email, password)) {
 			throw new CustomException(CustomErrorCode.CONTAIN_PRIVATE_INFORMATION);
 		}
 
@@ -34,12 +31,12 @@ public class PasswordValidation {
 		}
 
 		// 숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다.
-		if (!followRules()) {
+		if (!followRules(password)) {
 			throw new CustomException(CustomErrorCode.NOT_FOLLOW_RULES);
 		}
 
 		// 3회 이상 연속되는 문자 사용이 불가합니다.
-		if (isThreeConsecutiveLetters()) {
+		if (isThreeConsecutiveLetters(password)) {
 			throw new CustomException(CustomErrorCode.NOT_THREE_CONSECUTIVE);
 		}
 
@@ -49,14 +46,14 @@ public class PasswordValidation {
 		}
 	}
 
-	private boolean containPrivateInformation() {
+	private boolean containPrivateInformation(String account, String email, String password) {
 		int atIndex = email.indexOf("@");
 		String id = email.substring(0, atIndex);
 
 		return password.contains(account) || password.contains(id);
 	}
 
-	private boolean followRules() {
+	private boolean followRules(String password) {
 		boolean numberEnglish = Pattern.matches("^(?=.*[0-9]+)(?=.*[a-zA-Z]+).+", password);
 		boolean englishSpecialSymbol = Pattern.matches("^(?=.*[a-zA-Z]+)(?=.*[!@#$%^&*]+).+", password);
 		boolean specialSymbolsNumber = Pattern.matches("^(?=.*[!@#$%^&*]+)(?=.*[0-9]+).+", password);
@@ -64,7 +61,7 @@ public class PasswordValidation {
 		return numberEnglish || englishSpecialSymbol || specialSymbolsNumber;
 	}
 
-	private boolean isThreeConsecutiveLetters() {
+	private boolean isThreeConsecutiveLetters(String password) {
 		int count = 1;
 		for (int i = 1; i < password.length(); i++) {
 			if (password.charAt(i - 1) == password.charAt(i)) {

--- a/src/main/java/com/snsIntegrationFeedService/user/service/PasswordValidation.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/PasswordValidation.java
@@ -12,7 +12,11 @@ public class PasswordValidation {
 	String account;
 	String email;
 	String password;
-	CommonPassword commonPassword;
+	private final CommonPassword commonPassword;
+
+	public PasswordValidation(CommonPassword commonPassword) {
+		this.commonPassword = commonPassword;
+	}
 
 	public void validatePassword(SignupRequestDto requestDto) {
 		this.account = requestDto.getAccount();

--- a/src/main/java/com/snsIntegrationFeedService/user/service/PasswordValidation.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/PasswordValidation.java
@@ -1,0 +1,78 @@
+package com.snsIntegrationFeedService.user.service;
+
+import com.snsIntegrationFeedService.common.error.CustomErrorCode;
+import com.snsIntegrationFeedService.common.exception.CustomException;
+import com.snsIntegrationFeedService.user.dto.SignupRequestDto;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class PasswordValidation {
+	String account;
+	String email;
+	String password;
+	CommonPassword commonPassword;
+
+	public void validatePassword(SignupRequestDto requestDto) {
+		this.account = requestDto.getAccount();
+		this.email = requestDto.getEmail();
+		this.password = requestDto.getPassword();
+
+		// 다른 개인 정보와 유사한 비밀번호는 사용할 수 없다.
+		if (containPrivateInformation()) {
+			throw new CustomException(CustomErrorCode.CONTAIN_PRIVATE_INFORMATION);
+		}
+
+		// 비밀번호는 최소 10자 이상이어야 한다.
+		if (password.length() < 10) {
+			throw new CustomException(CustomErrorCode.LACK_OF_CHARACTERS);
+		}
+
+		// 숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다.
+		if (!followRules()) {
+			throw new CustomException(CustomErrorCode.NOT_FOLLOW_RULES);
+		}
+
+		// 3회 이상 연속되는 문자 사용이 불가합니다.
+		if (isThreeConsecutiveLetters()) {
+			throw new CustomException(CustomErrorCode.NOT_THREE_CONSECUTIVE);
+		}
+
+		// 통상적으로 자주 사용되는 비밀번호는 사용할 수 없습니다.
+		if (commonPassword.isCommonPassword(password)) {
+			throw new CustomException(CustomErrorCode.NOT_AVAILABLE_COMMON_PASSWORD);
+		}
+	}
+
+	private boolean containPrivateInformation() {
+		int atIndex = email.indexOf("@");
+		String id = email.substring(0, atIndex);
+
+		return password.contains(account) || password.contains(id);
+	}
+
+	private boolean followRules() {
+		boolean numberEnglish = Pattern.matches("^(?=.*[0-9]+)(?=.*[a-zA-Z]+).+", password);
+		boolean englishSpecialSymbol = Pattern.matches("^(?=.*[a-zA-Z]+)(?=.*[!@#$%^&*]+).+", password);
+		boolean specialSymbolsNumber = Pattern.matches("^(?=.*[!@#$%^&*]+)(?=.*[0-9]+).+", password);
+
+		return numberEnglish || englishSpecialSymbol || specialSymbolsNumber;
+	}
+
+	private boolean isThreeConsecutiveLetters() {
+		int count = 1;
+		for (int i = 1; i < password.length(); i++) {
+			if (password.charAt(i - 1) == password.charAt(i)) {
+				count++;
+			} else {
+				count = 1;
+			}
+			if (count == 3) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
@@ -1,4 +1,50 @@
 package com.snsIntegrationFeedService.user.service;
 
+import com.snsIntegrationFeedService.common.error.CustomErrorCode;
+import com.snsIntegrationFeedService.common.exception.CustomException;
+import com.snsIntegrationFeedService.user.dto.SignupRequestDto;
+import com.snsIntegrationFeedService.user.entity.User;
+import com.snsIntegrationFeedService.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public void signup(SignupRequestDto requestDto) {
+		String account = requestDto.getAccount();
+		String email = requestDto.getEmail();
+		String password = requestDto.getPassword();
+
+		// account로 검증하여 회원이 존재하면 예외 발생
+		User targetUser = findUser(account);
+		if (targetUser != null) {
+			throw new CustomException(CustomErrorCode.USER_ALREADY_EXIST);
+		}
+
+		// 비밀번호 검증이 완료되면 password encoding
+		validatePassword(password);
+		password = passwordEncoder.encode(password);
+
+		User user = User.builder()
+				.account(account).email(email)
+				.password(password).build();
+		userRepository.save(user);
+	}
+
+	private User findUser(String account) {
+		return userRepository.findByAccount(account).orElse(null);
+	}
+
+	private void validatePassword(String password) {
+
+	}
+
 }

--- a/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final PasswordValidation passwordValidation;
 
 	public void signup(SignupRequestDto requestDto) {
 		String account = requestDto.getAccount();
@@ -30,7 +31,7 @@ public class UserService {
 		}
 
 		// 비밀번호 검증이 완료되면 password encoding
-		validatePassword(password);
+		passwordValidation.validatePassword(requestDto);
 		password = passwordEncoder.encode(password);
 
 		User user = User.builder()
@@ -41,10 +42,6 @@ public class UserService {
 
 	private User findUser(String account) {
 		return userRepository.findByAccount(account).orElse(null);
-	}
-
-	private void validatePassword(String password) {
-
 	}
 
 }


### PR DESCRIPTION
## 관련 Issue

* #5 

## 변경 사항

- [x] 회원가입 API 기능 구현 -> 포스트맨 체크 완료
  * 비밀번호 검증 로직 추가할 시 포스트맨 체크 사진 첨부 예정
- [x] Application단에서 테스트 편의를 위해 Security 기능을 off하였습니다. Security 구현 시 다시 이 옵션은 없애도록 하겠습니다.
- [x] 비밀번호 검증 로직을 추가하였습니다.
  * 통상적으로 자주 사용되는 비밀번호는 [Top 200 most common passwords](https://nordpass.com/most-common-passwords-list/)를 참고하였습니다.


## Check List

- [x] 포스트맨으로 체크해 보았나요?

|비밀번호에 개인정보를 포함하는 경우|비밀번호가 9자 이하인 경우|
|---|---|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/38d3ec34-6fdc-4be8-be74-90308811d8e7)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/5ea0c6b4-7a35-4cab-bc0f-061a069f25d0)|
|숫자, 문자, 특수문자 중 2가지 이상을 포함하지 않는 경우|3회 이상 연속되는 문자를 사용할 경우|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/07d7f101-7794-40b2-86d3-f0ff8829bcee)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/c65e5d72-562f-4092-856b-76db1859790d)|
|통상적으로 사용되는 비밀번호를 사용했을 경우||
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/ab77bd1b-d424-4c00-8083-6aea13775c64)||
|회원가입 완료|같은 메일 다른 계정 가입 가능
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/67b9f072-5327-4c16-ad05-d8333866bcfe)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/2a1d4a2a-bde1-4d0b-b4f8-2ecdabef4487)|
|같은 계정 가입 불가|이메일 구조 검증|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/d54f8152-a9b5-45b0-bbaf-4c77ef9be356)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/ea0e2e10-86a7-4f00-9b66-657109892512)|








## 트러블 슈팅

### 1. 컬럼 기본값 설정 오류 문제

---

<br>

* **오류 발생 상황**

User Entity에서 isAccessed를 다음과 같이 설정했는데,

```java
@Column(nullable = false)
private Boolean isAccessed = false;
```

UserService 에서 다음과 같이 User 객체를 @Builder 로 생성한 다음, 저장하려고 했더니 오류가 발생하였다.

```java
public void signup(SignupRequestDto requestDto) {
	String account = requestDto.getAccount(); 
	User = User.builder().account(account).build();
	userRepository.save(user);
}
```

발생한 오류

```java
java.sql.SQLIntegrityConstraintViolationException: Column 'is_accessed' cannot be null
```

---

<br>

* **오류 원인**

찾아보니 내가 설정해 준 기본 값 false는 Java 객체 레벨에서 설정을 해 준 것이지, 데이터베이스 레벨에서의 초기화가 아니라고 한다.

User 테이블이 만들어지는 SQL문을 살펴보면 다음과 같이 기본값이 잡혀 있지 않음을 알 수 있다. Column에 기본값이 잡힌다면 `is_accessed bit default false not null`이 되어야 한다.

```SQL
create table user (
    is_accessed bit not null,
	...
)
```

---

<br>

* **해결 방법**

1. 생성자를 통해 객체를 만들 때

`@ColumnDefault` 를 사용하여 디폴트 값을 정해준 뒤, 나머지 필드를 생성자로 만들어서 객체를 생성한 뒤 DB에 저장한다.

```java
@Column(nullable = false)
@ColumnDefault("false")		// JPA Annotation
private Boolean isAccessed;

User user = new User(email, password, account);
```

2. `@Builder`를 통해 객체를 만들 때

`@Builder.Default` 를 사용하여 isAccessed 필드를 `@Builder`의 Default 값으로 설정해준다.

```java
@Column(nullable = false)
@Builder.Default
private Boolean isAccessed = false;

User user = User.builder()
	.email(email).password(password)
	.account(account).build();
```

참고링크
- [JPA @ColumnDefault에 대한 오해, 컬럼 default 적용하기, @ColumnDefault not working 해결하기, @DynamicInsert](https://eocoding.tistory.com/71)

---

### 2. NullPointerException

* **발생한 오류**

```java
java.lang.NullPointerException:
Cannot invoke "PasswordValidation.validatePassword(SignupRequestDto)"
because "this.passwordValidation" is null
```

* **내 코드**

```java
public class UserService {

	private final UserRepository userRepository;
	private final PasswordEncoder passwordEncoder;
	PasswordValidation passwordValidation;

	public void signup(SignupRequestDto requestDto) {
		...
		// 비밀번호 검증이 완료되면 password encoding
		passwordValidation.validatePassword(requestDto);
		...
	}
}
```

* **원인**

객체를 초기화해주지 않고 선언만 해서 PasswordValidation 객체가 null값이 되어서 해당 객체의 메서드를 불러오지 못한 것이 문제였다.

* **해결**

PasswordValidation을 Bean으로 등록한다.(의존성 주입)