### PR TITLE
[feature] 로그인 API 및 Spring Security 

### DIFF
--- a/src/main/java/com/snsIntegrationFeedService/SnsIntegrationFeedServiceApplication.java
+++ b/src/main/java/com/snsIntegrationFeedService/SnsIntegrationFeedServiceApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class SnsIntegrationFeedServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,80 @@
+package com.snsIntegrationFeedService.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snsIntegrationFeedService.common.dto.ApiResponseDto;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+	private final JwtUtil jwtUtil;
+
+	public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+		this.jwtUtil = jwtUtil;
+		setFilterProcessesUrl("/api/users/login");
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+		log.info("로그인 시도");
+		try {
+			LoginRequestDto requestDto = new ObjectMapper().readValue(request.getInputStream(), LoginRequestDto.class);
+
+			return getAuthenticationManager().authenticate(
+					new UsernamePasswordAuthenticationToken(
+							requestDto.getAccount(),
+							requestDto.getPassword(),
+							null
+					)
+			);
+		} catch (IOException e) {
+			log.error(e.getMessage());
+			throw new RuntimeException(e.getMessage());
+		}
+	}
+
+	@Override
+	protected void successfulAuthentication(HttpServletRequest request,
+											HttpServletResponse response,
+											FilterChain chain,
+											Authentication authResult) throws IOException {
+		log.info("로그인 성공 및 JWT 생성");
+		String account = ((UserDetailsImpl) authResult.getPrincipal()).getAccount();
+
+		String token = jwtUtil.createToken(account);
+		response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+
+		response.setStatus(200);
+		response.setContentType("application/json");
+		String result = new ObjectMapper().writeValueAsString(
+				new ApiResponseDto(HttpStatus.OK.value(), "로그인에 성공하였습니다.")
+		);
+
+		response.getOutputStream().print(result);
+	}
+
+	@Override
+	protected void unsuccessfulAuthentication(HttpServletRequest request,
+											  HttpServletResponse response,
+											  AuthenticationException failed) throws IOException {
+		log.info("로그인 실패");
+
+		response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		response.setContentType("application/json");
+		String result = new ObjectMapper().writeValueAsString(
+				new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "로그인에 실패하였습니다.")
+		);
+
+		response.getOutputStream().print(result);
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthenticationFilter.java
@@ -2,8 +2,8 @@ package com.snsIntegrationFeedService.common.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snsIntegrationFeedService.common.dto.ApiResponseDto;
+import com.snsIntegrationFeedService.user.dto.LoginRequestDto;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		response.setStatus(200);
 		response.setContentType("application/json");
 		String result = new ObjectMapper().writeValueAsString(
-				new ApiResponseDto(HttpStatus.OK.value(), "로그인에 성공하였습니다.")
+				new ApiResponseDto(HttpStatus.OK.value(), "login success")
 		);
 
 		response.getOutputStream().print(result);
@@ -72,7 +72,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 		response.setContentType("application/json");
 		String result = new ObjectMapper().writeValueAsString(
-				new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "로그인에 실패하였습니다.")
+				new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "login failure")
 		);
 
 		response.getOutputStream().print(result);

--- a/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthorizationFilter.java
@@ -38,13 +38,15 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		String tokenValue = jwtUtil.getTokenFromRequest(req);
 
 		if (StringUtils.hasText(tokenValue)) {
-
+			// 토큰 검증
 			if (notValidate(res, tokenValue)) return;
 
+			// 토큰에서 사용자 정보 가져오기
 			Claims info = getClaims(res, tokenValue);
 			if (info == null) return;
 
-			if (verifyAuthentication(info)) return;
+			// 사용자 정보 인증 객체에 담기
+			if (userInfoInAuthentication(info)) return;
 		}
 
 		filterChain.doFilter(req, res);
@@ -84,7 +86,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		return info;
 	}
 
-	private boolean verifyAuthentication(Claims info) {
+	private boolean userInfoInAuthentication(Claims info) {
 		try {
 			setAuthentication(info.getSubject());
 		} catch (Exception e) {

--- a/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/JwtAuthorizationFilter.java
@@ -1,0 +1,112 @@
+package com.snsIntegrationFeedService.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snsIntegrationFeedService.common.dto.ApiResponseDto;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+	private final UserDetailsServiceImpl userDetailsService;
+
+	public JwtAuthorizationFilter(JwtUtil jwtUtil, UserDetailsServiceImpl userDetailsService) {
+		this.jwtUtil = jwtUtil;
+		this.userDetailsService = userDetailsService;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest req,
+									HttpServletResponse res,
+									FilterChain filterChain) throws ServletException, IOException {
+		// Header에서 jwt 토큰 받아오기
+		String tokenValue = jwtUtil.getTokenFromRequest(req);
+
+		if (StringUtils.hasText(tokenValue)) {
+
+			if (notValidate(res, tokenValue)) return;
+
+			Claims info = getClaims(res, tokenValue);
+			if (info == null) return;
+
+			if (verifyAuthentication(info)) return;
+		}
+
+		filterChain.doFilter(req, res);
+	}
+
+
+	private boolean notValidate(HttpServletResponse res, String tokenValue) throws IOException {
+		if (!jwtUtil.validateToken(tokenValue)) {
+			res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			res.setContentType("application/json");
+			String result = new ObjectMapper().writeValueAsString(
+					new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN")
+			);
+
+			res.getOutputStream().print(result);
+			return true;
+		}
+		return false;
+	}
+
+	private Claims getClaims(HttpServletResponse res, String tokenValue) throws IOException {
+		Claims info;
+
+		try {
+			info = jwtUtil.getUserInfoFromToken(tokenValue);
+		} catch (Exception e) {
+			// JWT 검증에 실패한 경우 처리
+			res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			res.setContentType("application/json");
+			String result = new ObjectMapper().writeValueAsString(
+					new ApiResponseDto(HttpStatus.BAD_REQUEST.value(), "INVALID_TOKEN")
+			);
+
+			res.getOutputStream().print(result);
+			return null;
+		}
+		return info;
+	}
+
+	private boolean verifyAuthentication(Claims info) {
+		try {
+			setAuthentication(info.getSubject());
+		} catch (Exception e) {
+			// 인증 처리에 실패한 경우 처리
+			log.error(e.getMessage());
+			return true;
+		}
+		return false;
+	}
+
+	// 인증 처리
+	public void setAuthentication(String account) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		Authentication authentication = createAuthentication(account);
+		context.setAuthentication(authentication);
+
+		SecurityContextHolder.setContext(context);
+	}
+
+	// 인증 객체 생성
+	private Authentication createAuthentication(String account) {
+		UserDetails userDetails = userDetailsService.loadUserByUsername(account);
+		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/common/security/JwtUtil.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/JwtUtil.java
@@ -1,0 +1,81 @@
+package com.snsIntegrationFeedService.common.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+	public static final String AUTHORIZATION_HEADER = "Authorization";        // Header KEY 값
+	public static final String BEARER_PREFIX = "Bearer ";        // Token 식별자
+	private static final long TOKEN_TIME = 30 * 60 * 1000L;        // 토큰 만료시간: 30 분
+
+	@Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+	private String secretKey;
+	private Key key;
+	private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+	// 로그 설정
+	public static final Logger logger = LoggerFactory.getLogger("JWT 관련 로그");
+
+	@PostConstruct
+	public void init() {
+		byte[] bytes = Base64.getDecoder().decode(secretKey);
+		key = Keys.hmacShaKeyFor(bytes);
+	}
+
+	// JWT 생성
+	public String createToken(String account) {
+		Date date = new Date();
+
+		return BEARER_PREFIX +
+				Jwts.builder()
+						.setSubject(account) // 사용자 식별자값
+						.setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
+						.setIssuedAt(date) // 발급일
+						.signWith(key, signatureAlgorithm) // 암호화 알고리즘
+						.compact();
+	}
+
+	// HttpServletRequest 에서 Header Value : JWT 가져오기
+	public String getTokenFromRequest(HttpServletRequest req) {
+		String bearerToken = req.getHeader(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+			return bearerToken.substring(BEARER_PREFIX.length());
+		}
+		return null;
+	}
+
+	// 토큰 검증
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (SecurityException | MalformedJwtException e) {
+			logger.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+		} catch (ExpiredJwtException e) {
+			logger.error("Expired JWT token, 만료된 JWT token 입니다.");
+		} catch (UnsupportedJwtException e) {
+			logger.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+		} catch (IllegalArgumentException e) {
+			logger.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+		}
+		return false;
+	}
+
+	// 토큰에서 사용자 정보 가져오기
+	public Claims getUserInfoFromToken(String token) {
+		return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/common/security/LoginRequestDto.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.snsIntegrationFeedService.common.security;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+	private String account;
+	private String password;
+}

--- a/src/main/java/com/snsIntegrationFeedService/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/UserDetailsImpl.java
@@ -1,0 +1,65 @@
+package com.snsIntegrationFeedService.common.security;
+
+import com.snsIntegrationFeedService.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+	private final User user;
+
+	public UserDetailsImpl(User user) {
+		this.user = user;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public String getAccount() {
+		return user.getAccount();
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return null;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		String authority = "ROLE_USER";
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.snsIntegrationFeedService.common.security;
+
+import com.snsIntegrationFeedService.user.entity.User;
+import com.snsIntegrationFeedService.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+	private final UserRepository userRepository;
+
+	public UserDetailsServiceImpl(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String account) throws UsernameNotFoundException {
+		User user = userRepository.findByAccount(account)
+				.orElseThrow(() -> new UsernameNotFoundException("Not found " + account));
+
+		return new UserDetailsImpl(user);
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/WebSecurityConfig.java
@@ -1,0 +1,65 @@
+package com.snsIntegrationFeedService.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity  // Spring Security 지원을 가능하게 함
+@EnableMethodSecurity(securedEnabled = true)
+public class WebSecurityConfig {
+	private final JwtUtil jwtUtil;
+	private final UserDetailsServiceImpl userDetailsService;
+	private final AuthenticationConfiguration authenticationConfiguration;
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+		return configuration.getAuthenticationManager();
+	}
+
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+		JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+		filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+		return filter;
+	}
+
+	@Bean
+	public JwtAuthorizationFilter jwtAuthorizationFilter() {
+		return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// CSRF 설정
+		http.csrf(AbstractHttpConfigurer::disable);
+
+		// Session -> 사용하지 않음.
+		http.sessionManagement(sessionManagement ->
+				sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+		http.authorizeHttpRequests(authorizeHttpRequests ->
+				authorizeHttpRequests
+						.requestMatchers(HttpMethod.POST, "/api/users/**").permitAll() // '/api/users'로 시작하는 요청 중 모든 POST 접근 허가
+						.requestMatchers("/swagger-ui/**", "/v3/**").permitAll() // swagger-ui 와 관련된 모든 요청 접근 허가
+						.anyRequest().authenticated() // 그 외 모든 요청 인증처리
+		);
+
+		// 필터 관리
+		http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+		http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/snsIntegrationFeedService/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/dto/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package com.snsIntegrationFeedService.common.security;
+package com.snsIntegrationFeedService.user.dto;
 
 import lombok.Getter;
 


### PR DESCRIPTION
## 관련 Issue

* #10 

<br>

## 변경 사항

* Login을 할 수 있습니다.
  * `LoginRequestDto` (account, password)를 받아 `/api/users/login`으로 `POST` 요청을 보내면 포스트맨 헤더 `Authorization` Key값의 Value에 JWT token이 발급됩니다.
*  `/api/users`로 시작하는 POST요청(회원가입, 로그인), Swagger-ui 요청 이외에는 모두 인증처리되어야 합니다. (헤더에 JWT가 있어야 합니다.)
* 컨트롤러에서 유저의 정보를 받아오고 싶은 경우 매개변수에 `@AuthenticationPrincipal UserDetailsImpl userDetails`를 넣어주고, `userDetails.getUser()`로 User의 정보를 받아올 수 있습니다.

ex. 회원정보 수정

*Controller*

```java
@PatchMapping("/info")
public ResponseEntity<ApiResponseDto> editUserInfo(
		@RequestBody EditUserRequestDto requestDto,
		@AuthenticationPrincipal UserDetailsImpl userDetails) {
	userService.editUserInfo(requestDto, userDetails.getUser());
	return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(),"성공적으로 변경되었습니다."));
}
```

*Service*

```java
public void editUserInfo(EditUserRequestDto requestDto, User user) {
	User found = findUser(user.getAccount());
	if(found==null){
		throw new CustomException(CustomErrorCode.USER_NOT_FOUND);
	}
	found.editUserInfo(requestDto.getEmail());
}
```

<br>

## Check List

- [x] 포스트맨으로 체크해 보았나요?

<br>

---

### 로그인 검증

다음과 같은 회원정보를 가지고 있는 회원이 있습니다.

```json
{
	"account":"dummyAccount",
	"password":"dummyPassword1"
}
```

계정이 없거나, 틀린 비밀번호의 경우 로그인이 실패합니다.

|계정 없음 ->로그인 실패|틀린 비밀번호 -> 로그인 실패|
|---|---|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/2bca16c9-ac18-42c9-8e6c-8f8bf2c649b1)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/3ecd75fb-4431-4921-85cc-8dd3ad5746af)|

올바른 계정과 비밀번호를 입력한 경우 로그인을 성공하고, 토큰을 생성합니다.
토큰은 [jwt.io](https://jwt.io/)에서 검증하였습니다.

|로그인 성공-> 토큰 발급|토큰 검증|
|---|---|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/4162ef9c-3d1a-4cb5-86ae-e72458d73041)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/f6c3b75a-4f82-4341-86de-5a5a6fe78ee5)|

-> **로그인 테스트 완료**

<br>

---

### 인가 검증

회원가입, 로그인 이외에 다른 API 요청은 인가 절차를 거쳐야 합니다.
다음과 같은 포스트가 있습니다.

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/3b646524-a887-45e9-ba57-fd3c18b2dbe3)

|토큰이 없을 때 -> 403 Forbidden 코드|토큰이 있을 때 -> 인가 성공 -> 포스트 상세 보기 성공|
|---|---|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/b87d23ec-f5b8-404c-8463-98ea882d3cdb)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/cca4e1f6-f52c-4e6d-a2b2-62169d8cea14)|

-> **인가 검증 완료**

<br>

---

### 토큰에서 유저정보 불러오기 검증

```text
임의로 유저의 정보를 변경하는 메서드를 만들어 테스트하였습니다.
```

* 코드는 [변경 사항](##변경-사항)에 있는 코드와 같습니다.
* 컨트롤러 측 메서드는 email 정보를 dto로 받고 `UserDetailsImpl`에서 user를 매개변수로 받습니다.
* 서비스 측 메서드는 user의 account로 `findUser(account)`로 user를 찾은 뒤, 없다면 null을 있다면 user의 정보를 변경합니다.

dummy@test.com이라는 이메일을 가진 user가 있습니다. 

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/fa635d64-b908-4383-96ec-9ee7319f47fa)

update문이 성공적으로 날아감을 확인할 수 있습니다.

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/4a8af1da-d595-4b91-99ed-ceba25aa5c0b)

응답 확인

|updateDummy@test.com으로 변경|헤더에 넣은 인증처리된 토큰|
|---|---|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/bac2ab02-2eb4-422c-9f6f-3a40d2a479f1)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/7eca069b-5efb-47f0-841b-a86cdb755dfb)|

DB 확인

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/30e8401e-1b0a-4ede-bab1-8ef83156940a)

-> **토큰에서 유저정보 불러오기 테스트 완료**

<br>

---

## 트러블 슈팅

* **발생한 예외: `CharConversionException`**

```java
java.io.CharConversionException: Not an ISO 8859-1 character: [로]
```

* **내 코드**

```java
String result = new ObjectMapper().writeValueAsString(
		new ApiResponseDto(HttpStatus.OK.value(), "로그인 성공")
);

response.getOutputStream().print(result);
```

* **원인 분석**

`HttpServletResponse`의 기본 인코딩은 ISO 8859-1인데 이는 알파벳과 일부 특수기호만을 처리할 수 있고, 한글은 처리할 수 없다. 서블릿에서 한글을 제대로 사용하기 위해서는 전달되는 메시지가 한글을 처리할 수 있도록 response 객체의 한글 인코딩을 설정해주어야 한다.

* **해결**

객체의 인코딩을 바꾸지 않고 메시지를 영어(`login success`)로 바꾸었다.