### PR TITLE
[feature] 가입승인 API

### DIFF
--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/controller/CertificateCodeController.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/controller/CertificateCodeController.java
@@ -1,4 +1,31 @@
 package com.snsIntegrationFeedService.certificateCode.controller;
 
+import com.snsIntegrationFeedService.certificateCode.dto.CertificateCodeRequestDto;
+import com.snsIntegrationFeedService.certificateCode.service.CertificateCodeService;
+import com.snsIntegrationFeedService.common.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "승인코드 API", description = "승인코드와 관련된 API 정보를 담고 있습니다.")
 public class CertificateCodeController {
+	private final CertificateCodeService certificateCodeService;
+
+	@Operation(summary = "승인 요청", description = "가입 승인에 필요한 정보를 받아 검증한 뒤 유저의 가입을 승인합니다.")
+	@PostMapping("/verifications")
+	public ResponseEntity<ApiResponseDto> requestMembershipApproval(@RequestBody CertificateCodeRequestDto requestDto) {
+		certificateCodeService.requestMembershipApproval(requestDto);
+		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "가입 승인 완료"));
+	}
+
+
 }

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/dto/CertificateCodeRequestDto.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/dto/CertificateCodeRequestDto.java
@@ -1,0 +1,10 @@
+package com.snsIntegrationFeedService.certificateCode.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CertificateCodeRequestDto {
+	private String account;
+	private String password;
+	private Integer verificationCode;
+}

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/dto/CertificateCodeRequestDto.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/dto/CertificateCodeRequestDto.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 public class CertificateCodeRequestDto {
 	private String account;
 	private String password;
-	private Integer verificationCode;
+	private int verificationCode;
 }

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/entity/CertificateCode.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/entity/CertificateCode.java
@@ -2,10 +2,16 @@ package com.snsIntegrationFeedService.certificateCode.entity;
 
 import com.snsIntegrationFeedService.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CertificateCode {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/repository/CertificateCodeRepository.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/repository/CertificateCodeRepository.java
@@ -1,9 +1,13 @@
 package com.snsIntegrationFeedService.certificateCode.repository;
 
 import com.snsIntegrationFeedService.certificateCode.entity.CertificateCode;
+import com.snsIntegrationFeedService.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface CertificateCodeRepository extends JpaRepository<CertificateCode,Long> {
+public interface CertificateCodeRepository extends JpaRepository<CertificateCode, Long> {
+	Optional<CertificateCode> findByUser(User user);
 }

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/repository/CertificateCodeRepository.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/repository/CertificateCodeRepository.java
@@ -1,4 +1,9 @@
 package com.snsIntegrationFeedService.certificateCode.repository;
 
-public interface CertificateCodeRepository {
+import com.snsIntegrationFeedService.certificateCode.entity.CertificateCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CertificateCodeRepository extends JpaRepository<CertificateCode,Long> {
 }

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/service/CertificateCodeService.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/service/CertificateCodeService.java
@@ -1,4 +1,45 @@
 package com.snsIntegrationFeedService.certificateCode.service;
 
+import com.snsIntegrationFeedService.certificateCode.dto.CertificateCodeRequestDto;
+import com.snsIntegrationFeedService.certificateCode.entity.CertificateCode;
+import com.snsIntegrationFeedService.certificateCode.repository.CertificateCodeRepository;
+import com.snsIntegrationFeedService.common.error.CustomErrorCode;
+import com.snsIntegrationFeedService.common.exception.CustomException;
+import com.snsIntegrationFeedService.user.entity.User;
+import com.snsIntegrationFeedService.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class CertificateCodeService {
+	private final UserService userService;
+	private final CertificateCodeRepository certificateCodeRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public void requestMembershipApproval(CertificateCodeRequestDto requestDto) {
+		String account = requestDto.getAccount();
+		String password = requestDto.getPassword();
+		Integer verificationCode = requestDto.getVerificationCode();
+
+		// password 확인
+		User user = userService.findUser(account);
+		if (!user.getPassword().equals(passwordEncoder.encode(password))) {
+			throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
+		}
+
+		// 승인 코드 확인
+		CertificateCode certificateCode = certificateCodeRepository.findByUser(user).orElseThrow(
+				() -> new CustomException(CustomErrorCode.CERTIFICATECODE_NOT_FOUND)
+		);
+		if (!certificateCode.getCode().equals(verificationCode)) {
+			throw new CustomException(CustomErrorCode.CERTIFICATECODE_NOT_MATCH);
+		}
+
+		user.approveUser();
+	}
+
 }

--- a/src/main/java/com/snsIntegrationFeedService/certificateCode/service/CertificateCodeService.java
+++ b/src/main/java/com/snsIntegrationFeedService/certificateCode/service/CertificateCodeService.java
@@ -27,7 +27,7 @@ public class CertificateCodeService {
 
 		// password 확인
 		User user = userService.findUser(account);
-		if (!user.getPassword().equals(passwordEncoder.encode(password))) {
+		if (!passwordEncoder.matches(password, user.getPassword())) {
 			throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
 		}
 

--- a/src/main/java/com/snsIntegrationFeedService/common/error/CustomErrorCode.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/error/CustomErrorCode.java
@@ -20,7 +20,13 @@ public enum CustomErrorCode {
 	NOT_FOLLOW_RULES(HttpStatus.BAD_REQUEST.value(),
 			"숫자, 문자, 특수문자 중 2가지 이상을 포함해야 합니다."),
 	NOT_THREE_CONSECUTIVE(HttpStatus.BAD_REQUEST.value(),
-			"3회 이상 연속되는 문자 사용이 불가합니다.");
+			"3회 이상 연속되는 문자 사용이 불가합니다."),
+	CERTIFICATECODE_NOT_FOUND(HttpStatus.NOT_FOUND.value(),
+			"승인코드가 존재하지 않습니다."),
+	PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST.value(),
+			"비밀번호가 일치하지 않습니다."),
+	CERTIFICATECODE_NOT_MATCH(HttpStatus.BAD_REQUEST.value(),
+			"승인코드가 일치하지 않습니다.");
 
 	private final int errorCode;
 	private final String errorMessage;

--- a/src/main/java/com/snsIntegrationFeedService/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/snsIntegrationFeedService/common/security/WebSecurityConfig.java
@@ -53,6 +53,7 @@ public class WebSecurityConfig {
 				authorizeHttpRequests
 						.requestMatchers(HttpMethod.POST, "/api/users/**").permitAll() // '/api/users'로 시작하는 요청 중 모든 POST 접근 허가
 						.requestMatchers("/swagger-ui/**", "/v3/**").permitAll() // swagger-ui 와 관련된 모든 요청 접근 허가
+						.requestMatchers(HttpMethod.POST, "/api/verifications").permitAll() // 가입승인 API 요청 허가
 						.anyRequest().authenticated() // 그 외 모든 요청 인증처리
 		);
 

--- a/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
@@ -25,7 +25,6 @@ public class UserController {
 	@PostMapping("/signup")
 	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
 		userService.signup(requestDto);
-		userService.issueCertificateCode(requestDto);
 		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "회원 가입 완료"));
 	}
 

--- a/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/controller/UserController.java
@@ -25,6 +25,7 @@ public class UserController {
 	@PostMapping("/signup")
 	public ResponseEntity<ApiResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
 		userService.signup(requestDto);
+		userService.issueCertificateCode(requestDto);
 		return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.CREATED.value(), "회원 가입 완료"));
 	}
 

--- a/src/main/java/com/snsIntegrationFeedService/user/entity/User.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/entity/User.java
@@ -39,4 +39,8 @@ public class User {
 
 	@OneToOne(mappedBy = "user")
 	private CertificateCode certificateCode;
+
+	public void approveUser() {
+		this.isAccessed = true;
+	}
 }

--- a/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
 		userRepository.save(user);
 	}
 
-	private User findUser(String account) {
+	public User findUser(String account) {
 		return userRepository.findByAccount(account).orElse(null);
 	}
 

--- a/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
@@ -44,13 +44,14 @@ public class UserService {
 				.account(account).email(email)
 				.password(password).build();
 		userRepository.save(user);
+		issueCertificateCode(account);
 	}
 
-	public void issueCertificateCode(SignupRequestDto requestDto) {
-		User user = findUser(requestDto.getAccount());
+	public void issueCertificateCode(String account) {
+		User foundUser = findUser(account);
 		Integer code = generateCode();
 		CertificateCode certificateCode = CertificateCode.builder()
-				.Code(code).user(user).build();
+				.Code(code).user(foundUser).build();
 		certificateCodeRepository.save(certificateCode);
 	}
 

--- a/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.snsIntegrationFeedService.user.service;
 
+import com.snsIntegrationFeedService.certificateCode.entity.CertificateCode;
+import com.snsIntegrationFeedService.certificateCode.repository.CertificateCodeRepository;
+import com.snsIntegrationFeedService.certificateCode.service.CertificateCodeService;
 import com.snsIntegrationFeedService.common.error.CustomErrorCode;
 import com.snsIntegrationFeedService.common.exception.CustomException;
 import com.snsIntegrationFeedService.user.dto.SignupRequestDto;
@@ -10,12 +13,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Random;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class UserService {
 
 	private final UserRepository userRepository;
+	private final CertificateCodeRepository certificateCodeRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final PasswordValidation passwordValidation;
 
@@ -40,8 +46,28 @@ public class UserService {
 		userRepository.save(user);
 	}
 
+	public void issueCertificateCode(SignupRequestDto requestDto) {
+		User user = findUser(requestDto.getAccount());
+		Integer code = generateCode();
+		CertificateCode certificateCode = CertificateCode.builder()
+				.Code(code).user(user).build();
+		certificateCodeRepository.save(certificateCode);
+	}
+
 	public User findUser(String account) {
 		return userRepository.findByAccount(account).orElse(null);
 	}
 
+	private Integer generateCode() {
+		Random random = new Random();
+		int code = 0;
+		int place = 1;
+		while (code / 100000 == 0) {
+			int num = random.nextInt(9) + 1;
+			System.out.println("num = " + num);
+			code += num * place;
+			place *= 10;
+		}
+		return code;
+	}
 }

--- a/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
+++ b/src/main/java/com/snsIntegrationFeedService/user/service/UserService.java
@@ -64,7 +64,6 @@ public class UserService {
 		int place = 1;
 		while (code / 100000 == 0) {
 			int num = random.nextInt(9) + 1;
-			System.out.println("num = " + num);
 			code += num * place;
 			place *= 10;
 		}


### PR DESCRIPTION
## 관련 Issue

* #11

<br>

## 변경 사항

* `UserService`에서 단순하게 승인코드 객체를 저장만 하기 때문에 여기서는 `CertificateCodeService`가 아니라 `CertificateCodeRepository`를 가져왔습니다.
<br>

* 회원가입을 하면 승인코드가 발급됩니다.
  * `UserService`에 `generateCode()` 코드 발급 메서드 추가
  * `signup()` 메서드에 `issueCertificateCode()` 메서드 추가
<br>

* `User` Entity에 `approveUser()` 메서드 추가
<br>

* 가입승인 API는 `Security` 거치지 않아도 되도록 설정
  * 서비스 요구사항에서 `계정, 비밀번호, 인증코드가 올바르게 입력되었을 시 가입승인이 되어 서비스 이용이 가능합니다`라는 문구로 미루어 볼 때, 이미 로그인이 되어 있다면 계정과 비밀번호를 입력할 이유가 없을 것 같아 `인증(로그인)을 거치지 않아도 API를 요청할 수 있다`로 이해하여 Security를 통과하도록 설정했습니다. 이 부분에 대한 다른 의견이 있으시면 수정하도록 하겠습니다!
<br>

* 가입 승인 API 요청 시, 계정, 비밀번호, 인증코드를 DTO로 받아서 다음을 검증하여 통과되면 유저의 `isAccessed` 필드를 `true`로 변경합니다.
  * 존재하는 계정인가?
  * 비밀번호가 일치하는가?
  * 인증코드가 일치하는가?
<br>

* 승인코드 Entity에 `@Builder`를 추가하였습니다.

<br>

## Check List

- [x] 포스트맨으로 체크해 보았나요?

* **다음의 회원정보로 회원가입**

```json
{
        "account":"jisoo",
        "email":"jisoo2@careerly.com",
        "password":"js12345678"
}
```

* **회원가입 및 `is_accessed = false` DB에서 확인**

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/7af39438-54a0-4867-88b7-41a66e294468)

* **승인코드 발급 DB에서 확인**

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/fd0dabe9-5a8c-46da-9942-8e7fa0bdaa77)

* **예외처리 테스트 및 API 요청 테스트**

|비밀번호 일치하지 않을 때|승인코드 일치하지 않을 때|
|:---:|:---:|
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/cacc2deb-a2a3-47f6-8581-66342a1f3f37)|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/09f2868a-3130-4097-bcbb-2499f8027867)|
|**가입승인 완료**||
|![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/6a81e1b3-8513-4bb4-a8c3-22c185a14f61)||

* **update문 쿼리 확인**

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/34452a3c-0bc6-4829-917d-a807ea9c996b)

* **is_accessed true로 변경되어 있는지 DB 확인**

![image](https://github.com/Wanted-Internship-Team-Careerly/SNS-Integration-Feed-Service/assets/130378232/4585262c-fd97-4263-a8a4-c1a1a1cd4aa2)

<br>

## 트러블 슈팅

**오류 발생**

다음과 같이 패스워드를 확인하는 작업에서 패스워드를 바르게 입력했음에도 패스워드가 일치하지 않다고 나옴.

```java
// password 확인

User user = userService.findUser(account);
if (!user.getPassword()
		.equals(passwordEncoder.encode(password))) {
	throw new CustomException(CustomErrorCode.PASSWORD_NOT_MATCH);
}
```

**원인**

passwordEncoder에서 인코딩을 해주면 매번 값이 달라지므로 일치할 수 없다.

**해결**

비밀번호 일치를 확인하여 boolean으로 return하는 메서드가 따로 있어 이 메서드로 변경해서 해결.

```java
passwordEncoder.matches(입력값, 저장되어있는 인코딩한 값);
```